### PR TITLE
Lawyer can have Jester as Client

### DIFF
--- a/TheOtherRoles/CustomOptionHolder.cs
+++ b/TheOtherRoles/CustomOptionHolder.cs
@@ -68,6 +68,7 @@ namespace TheOtherRoles {
         public static CustomOption jesterSpawnRate;
         public static CustomOption jesterCanCallEmergency;
         public static CustomOption jesterHasImpostorVision;
+        public static CustomOption jesterCanBeLawyerClient;
 
         public static CustomOption arsonistSpawnRate;
         public static CustomOption arsonistCooldown;
@@ -349,6 +350,7 @@ namespace TheOtherRoles {
             jesterSpawnRate = CustomOption.Create(60, cs(Jester.color, "Jester"), rates, null, true);
             jesterCanCallEmergency = CustomOption.Create(61, "Jester Can Call Emergency Meeting", true, jesterSpawnRate);
             jesterHasImpostorVision = CustomOption.Create(62, "Jester Has Impostor Vision", false, jesterSpawnRate);
+            jesterCanBeLawyerClient = CustomOption.Create(8999, "Jester Can Be Client Of Lawyer", false, jesterSpawnRate);
 
             arsonistSpawnRate = CustomOption.Create(290, cs(Arsonist.color, "Arsonist"), rates, null, true);
             arsonistCooldown = CustomOption.Create(291, "Arsonist Cooldown", 12.5f, 2.5f, 60f, 2.5f, arsonistSpawnRate);

--- a/TheOtherRoles/Patches/EndGamePatch.cs
+++ b/TheOtherRoles/Patches/EndGamePatch.cs
@@ -189,22 +189,25 @@ namespace TheOtherRoles.Patches {
             }
 
             // Possible Additional winner: Lawyer
-            if (!lawyerSoloWin && Lawyer.lawyer != null && Lawyer.target != null && !Lawyer.target.Data.IsDead) {
-                WinningPlayerData winningClient = null;
-                foreach (WinningPlayerData winner in TempData.winners) {
-                    if (winner.PlayerName == Lawyer.target.Data.PlayerName)
-                        winningClient = winner;
-                }
-                if (winningClient != null) { // The Lawyer wins if the client is winning (and alive, but if he wasn't the Lawyer shouldn't exist anymore)
-                    if (!TempData.winners.ToArray().Any(x => x.PlayerName == Lawyer.lawyer.Data.PlayerName))
-                        TempData.winners.Add(new WinningPlayerData(Lawyer.lawyer.Data));
-                    if (!Lawyer.lawyer.Data.IsDead) { // The Lawyer steals the clients win
-                        TempData.winners.Remove(winningClient);
-                        AdditionalTempData.additionalWinConditions.Add(WinCondition.AdditionalLawyerStolenWin);
-                    } else { // The Lawyer wins together with the client
-                        AdditionalTempData.additionalWinConditions.Add(WinCondition.AdditionalLawyerBonusWin);
+            if (!lawyerSoloWin && Lawyer.lawyer != null && Lawyer.target != null) {
+                if (!Lawyer.target.Data.IsDead || (Jester.jester != null && Lawyer.target == Jester.jester)) {
+                    WinningPlayerData winningClient = null;
+                    foreach (WinningPlayerData winner in TempData.winners) {
+                        if (winner.PlayerName == Lawyer.target.Data.PlayerName)
+                            winningClient = winner;
                     }
-                } 
+                    if (winningClient != null) { // The Lawyer wins if the client is winning (and alive, but if he wasn't the Lawyer shouldn't exist anymore)
+                        if (!TempData.winners.ToArray().Any(x => x.PlayerName == Lawyer.lawyer.Data.PlayerName))
+                            TempData.winners.Add(new WinningPlayerData(Lawyer.lawyer.Data));
+                        if (!Lawyer.lawyer.Data.IsDead) { // The Lawyer steals the clients win
+                            TempData.winners.Remove(winningClient);
+                            AdditionalTempData.additionalWinConditions.Add(WinCondition.AdditionalLawyerStolenWin);
+                        }
+                        else { // The Lawyer wins together with the client
+                            AdditionalTempData.additionalWinConditions.Add(WinCondition.AdditionalLawyerBonusWin);
+                        }
+                    }
+                }
             }
 
             // Possible Additional winner: Pursuer

--- a/TheOtherRoles/Patches/RoleAssignmentPatch.cs
+++ b/TheOtherRoles/Patches/RoleAssignmentPatch.cs
@@ -367,8 +367,9 @@ namespace TheOtherRoles.Patches {
             if (Lawyer.lawyer != null) {
                 var possibleTargets = new List<PlayerControl>();
                 foreach (PlayerControl p in PlayerControl.AllPlayerControls) {
-                    if (!p.Data.IsDead && !p.Data.Disconnected && p != Lovers.lover1 && p != Lovers.lover2 && (p.Data.Role.IsImpostor || p == Jackal.jackal))
-                        possibleTargets.Add(p);
+                    // Only allow Jester as client if setting is true
+                    if (!p.Data.IsDead && !p.Data.Disconnected && p != Lovers.lover1 && p != Lovers.lover2 && (p.Data.Role.IsImpostor || p == Jackal.jackal || (p == Jester.jester && Jester.canBeLawyerClient)))
+                    possibleTargets.Add(p);
                 }
                 if (possibleTargets.Count == 0) {
                     MessageWriter w = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.LawyerPromotesToPursuer, Hazel.SendOption.Reliable, -1);

--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -761,13 +761,17 @@ namespace TheOtherRoles
         public static void lawyerPromotesToPursuer() {
             PlayerControl player = Lawyer.lawyer;
             PlayerControl client = Lawyer.target;
+
+            // Don't promote to pursuer if target is jester and jester was exiled
+            if (client != null && client == Jester.jester && ExileController.Instance.exiled != null && ExileController.Instance.exiled.PlayerId == Jester.jester.PlayerId) return;
+
             Lawyer.clearAndReload();
             Pursuer.pursuer = player;
 
             if (player.PlayerId == PlayerControl.LocalPlayer.PlayerId && client != null) {
-                    Transform playerInfoTransform = client.nameText.transform.parent.FindChild("Info");
-                    TMPro.TextMeshPro playerInfo = playerInfoTransform != null ? playerInfoTransform.GetComponent<TMPro.TextMeshPro>() : null;
-                    if (playerInfo != null) playerInfo.text = "";
+                Transform playerInfoTransform = client.nameText.transform.parent.FindChild("Info");
+                TMPro.TextMeshPro playerInfo = playerInfoTransform != null ? playerInfoTransform.GetComponent<TMPro.TextMeshPro>() : null;
+                if (playerInfo != null) playerInfo.text = "";
             }
         }
 

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -70,12 +70,14 @@ namespace TheOtherRoles
             public static bool triggerJesterWin = false;
             public static bool canCallEmergency = true;
             public static bool hasImpostorVision = false;
+            public static bool canBeLawyerClient = false;
 
             public static void clearAndReload() {
                 jester = null;
                 triggerJesterWin = false;
                 canCallEmergency = CustomOptionHolder.jesterCanCallEmergency.getBool();
                 hasImpostorVision = CustomOptionHolder.jesterHasImpostorVision.getBool();
+                canBeLawyerClient = CustomOptionHolder.jesterCanBeLawyerClient.getBool();
             }
         }
 


### PR DESCRIPTION
Added option jesterCanBeLawyerClient to Jester. When active, Jester can be chosen as Client for the Lawyer. Lawyer steals victory from Jester when still alive and Jester voted out. Lawyer wins with Jester when dead and Jester voted out. Lawyer turns to Pursuer when Jester is normally killed.

closes #23 